### PR TITLE
Add support for syslogIdentifier.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ The appender can be configured with the following properties
        `logLoggerName` | true         | boolean | Determines whether the logger name is logged. This data is logged in the user field `LOG4J_LOGGER`.
        `logMdc`        | true         | boolean | Determines whether the [thread context][thread-context] is logged. Each key/value pair is logged as user field with the `mdcPrefix` prefix.
        `mdcPrefix`     | `LOG4J_MDC_` | String  | Determines how [MDC][mdc] keys should be prefixed when `logMdc` is set to true. Note that keys need to match the regex pattern `[A-Z0-9_]+` and are normalized otherwise.
+       `syslogIdentifier`| null       | String  | This data is logged in the user field `SYSLOG_IDENTIFIER`.  If this is not set, the underlying system will use the command name (usually `java`) instead.
 
 ### Runtime dependencies ###
     - Linux with systemd-journal

--- a/src/main/java/de/bwaldvogel/log4j/SystemdJournalAppender.java
+++ b/src/main/java/de/bwaldvogel/log4j/SystemdJournalAppender.java
@@ -27,6 +27,8 @@ public class SystemdJournalAppender extends AppenderSkeleton {
 
     private String mdcPrefix = "LOG4J_MDC_";
 
+    private String syslogIdentifier;
+
     public SystemdJournalAppender() {
         journalLibrary = (SystemdJournalLibrary) Native.loadLibrary("systemd-journal", SystemdJournalLibrary.class);
     }
@@ -84,6 +86,11 @@ public class SystemdJournalAppender extends AppenderSkeleton {
         args.add("PRIORITY=%d");
         args.add(Integer.valueOf(log4jLevelToJournalPriority(event.getLevel())));
 
+        if (syslogIdentifier != null && !syslogIdentifier.isEmpty()) {
+            args.add("SYSLOG_IDENTIFIER=%s");
+            args.add(syslogIdentifier);
+        }
+
         if (logThreadName) {
             args.add("THREAD_NAME=%s");
             args.add(event.getThreadName());
@@ -139,5 +146,13 @@ public class SystemdJournalAppender extends AppenderSkeleton {
 
     public void setMdcPrefix(String mdcPrefix) {
         this.mdcPrefix = normalizeKey(mdcPrefix);
+    }
+
+    public String getSyslogIdentifier() {
+        return syslogIdentifier;
+    }
+
+    public void setSyslogIdentifier(String syslogIdentifier) {
+        this.syslogIdentifier = syslogIdentifier;
     }
 }

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -12,3 +12,4 @@ log4j.appender.journal.logStacktrace=true
 log4j.appender.journal.logThreadName=true
 log4j.appender.journal.logLoggerName=true
 log4j.appender.journal.logMdc=true
+log4j.appender.journal.syslogIdentifier=log4journaltest


### PR DESCRIPTION
The journal field SYSLOG_IDENTIFIER is useful for tagging log messages with a system name / program name.  It is used on a larger granularity than the logger name, so I think it is useful to set it as a property on the appender, configured in log4j.properties.
