### PR TITLE
Configurable layout and optional stack trace in journal MESSAGE

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ The appender can be configured with the following properties
        Property name      | Default      | Type    | Description
        -------------------| ------------ | ------- | -----------
        `logStacktrace`    | true         | boolean | Determines whether the full exception stack trace is logged. This data is logged in the user field `STACKTRACE`.
+       `appendStacktrace` | true         | boolean | Determines whether the full exception stack trace is to be appended to the log message.
        `logThreadName`    | true         | boolean | Determines whether the thread name is logged. This data is logged in the user field `THREAD_NAME`.
        `logLoggerName`    | true         | boolean | Determines whether the logger name is logged. This data is logged in the user field `LOG4J_LOGGER`.
        `logAppenderName`  | true         | boolean | Determines whether the appender name is logged. This data is logged in the user field `LOG4J_APPENDER`.

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ log4j.appender.journal=de.bwaldvogel.SystemdJournalAppender
 log4j.appender.journal.logStacktrace=true
 log4j.appender.journal.logThreadName=true
 log4j.appender.journal.logLoggerName=true
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%-5p [%.20c] %m%n
 
 log4j.appender.console=org.apache.log4j.ConsoleAppender
 log4j.appender.console.layout=org.apache.log4j.PatternLayout
@@ -56,8 +58,7 @@ log4j.appender.console.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p [%.
 ```
 
 This will tell Log4j to log to [systemd journal][systemd-journal] as well as to stdout (console).
-Note that a layout is not set for the `SystemdJournalAppender` and would be ignored if given.
-This is because meta data of a log event such as the timestamp, the logger name or the Java thread name are mapped to [systemd-journal fields][systemd-journal-fields] and need not be rendered into a string that loses all the semantic information.
+Note that a layout set for the `SystemdJournalAppender` does not include the timestamp, as this will be provided by the journal viewer normally. In fact the layout is optional, because meta data of a log event such as the timestamp, the logger name or the Java thread name are mapped to [systemd-journal fields][systemd-journal-fields] and need not be rendered into a string that loses all the semantic information.
 
 ### `YourExample.java`
 ```java
@@ -80,7 +81,7 @@ Running this sample class will log a message to journald:
 
 ```
 # journalctl -n
-Okt 13 21:26:00 myhost java[2370]: this is an example
+Okt 13 21:26:00 myhost java[2370]: INFO  [YourExample] this is an example
 ```
 
 Use `journalctl -o verbose` to show all fields:

--- a/src/main/java/de/bwaldvogel/log4j/SystemdJournalAppender.java
+++ b/src/main/java/de/bwaldvogel/log4j/SystemdJournalAppender.java
@@ -46,7 +46,7 @@ public class SystemdJournalAppender extends AppenderSkeleton {
 
     @Override
     public boolean requiresLayout() {
-        return false;
+        return true;
     }
 
     private int log4jLevelToJournalPriority(Level level) {
@@ -83,7 +83,12 @@ public class SystemdJournalAppender extends AppenderSkeleton {
     protected void append(LoggingEvent event) {
         List<Object> args = new ArrayList<>();
 
-        args.add(event.getRenderedMessage());
+        if (this.layout != null) {
+            args.add(this.layout.format(event));
+        }
+        else {
+            args.add(event.getRenderedMessage());
+        }
 
         args.add("PRIORITY=%d");
         args.add(Integer.valueOf(log4jLevelToJournalPriority(event.getLevel())));

--- a/src/main/java/de/bwaldvogel/log4j/SystemdJournalAppender.java
+++ b/src/main/java/de/bwaldvogel/log4j/SystemdJournalAppender.java
@@ -27,6 +27,8 @@ public class SystemdJournalAppender extends AppenderSkeleton {
 
     private boolean logMdc = true;
 
+    private boolean appendStacktrace = false;
+
     private String mdcPrefix = "LOG4J_MDC_";
 
     private String syslogIdentifier;
@@ -82,13 +84,27 @@ public class SystemdJournalAppender extends AppenderSkeleton {
     @Override
     protected void append(LoggingEvent event) {
         List<Object> args = new ArrayList<>();
+        String message;
 
         if (this.layout != null) {
-            args.add(this.layout.format(event));
+            message = this.layout.format(event);
         }
         else {
-            args.add(event.getRenderedMessage());
+            message = event.getRenderedMessage();
         }
+        if (appendStacktrace) {
+            String[] s = event.getThrowableStrRep();
+            if (s != null) {
+                StringBuilder msgB = new StringBuilder(this.layout.format(event));
+                int len = s.length;
+                for(int i = 0; i < len; i++) {
+                    msgB.append(s[i]);
+                    msgB.append(LINE_SEPARATOR);
+                }
+                message = msgB.toString();
+            }
+        }
+        args.add(message);
 
         args.add("PRIORITY=%d");
         args.add(Integer.valueOf(log4jLevelToJournalPriority(event.getLevel())));
@@ -158,6 +174,10 @@ public class SystemdJournalAppender extends AppenderSkeleton {
 
     public void setLogMdc(boolean logMdc) {
         this.logMdc = logMdc;
+    }
+
+    public void setAppendStacktrace(boolean appendStacktrace) {
+        this.appendStacktrace = appendStacktrace;
     }
 
     public void setMdcPrefix(String mdcPrefix) {


### PR DESCRIPTION
This is my solution for #3 plus exception information.

It is not perfect and only for the 1.x version, but fixes the log4j-systemd-journal-appender limitations for me – now journalctl output is enough to replace my previous console logs. Message layout can be configured like it would be for a console output (but one would want to omit the timestamps) and exception stack trace can be included in the message too.

The layout for the appender is now optional, but log4j will complain if it is not set in the properties, which causes annoying warnings where one would expect the previous behaviour. This seems like a log4j limitation and I don't know how to fix it.

Exception stack trace inclusion is configured by a new 'appendStacktrace'. Having the stack trace in a separate journal field is still handled by 'logStacktrace'.

These changes are enough for our purposes and I am not able to commit more time to this issue, but I hope this can be still useful for upstream development.
